### PR TITLE
Changes to text in disclaimers

### DIFF
--- a/anthrocon_plugin/templates/preregistration/disclaimers.html
+++ b/anthrocon_plugin/templates/preregistration/disclaimers.html
@@ -1,0 +1,15 @@
+<hr/>
+
+<div style="font-weight:bold ; color:red ; margin-bottom:5px">Disclaimers:</div>
+<ul>
+    <li> Your registration may not be sold or transferred.</li>
+    <li> Attendees (including dealers) must abide by our <a target="_blank" href="{{CODE_OF_CONDUCT_URL}}">code of conduct</a>. </li>
+    <li> Submitting this form as a Dealer does not guarantee you will be selected for the Marketplace - it is only the application. </li>
+</ul>
+<br/>
+
+<script type="text/javascript">
+    $(document).ready(function(){
+        window.scrollTo(0,0);
+    });
+</script>


### PR DESCRIPTION
Changes the disclaimers on the pre-registration page to reflect Anthrocon's badge policies.
