### PR TITLE
Add description of badge types

### DIFF
--- a/anthrocon_plugin/templates/static_views/badge_descriptions.html
+++ b/anthrocon_plugin/templates/static_views/badge_descriptions.html
@@ -1,0 +1,37 @@
+<html>
+<head>
+    <title>Explanation of Badge Types</title>
+</head>
+<body>
+
+<h3 align="center">What do these badges mean?</h3>
+
+There are a few different badge types you can choose from when registering for {{ EVENT_NAME }}. Each comes with its own perks.
+
+<br/><br/><strong>Attending</strong>: An attending membership allows a member access to the convention for its duration (Thursday through Sunday), our conbook and other publications at the convention.
+
+<br/><br/><strong>Sponsor</strong>: Sponsors are generous patrons who like to help us provide even more services and events for our membership. A sponsor gets the full privileges of an attending membership, as well as the following:
+
+<ul>
+    <li>A nifty Sponsor ribbon</li>
+    <li>A free Anthrocon T-shirt</li>
+    <li>An expedited registration/badge pickup line on site</li>
+    <li>Advance admission to the Dealers' Room each day</li>
+</ul>
+
+<br/><strong>Supersponsor</strong>: We consider Supersponsors some of the most generous persons on the planet! We heap lavish praise and gifts unto them. A Supersponsor gets the full privileges of an attending membership, as well as the following:
+
+<ul>
+    <li>A nifty Supersponsor ribbon</li>
+    <li>A free Anthrocon T-shirt</li>
+    <li>An expedited registration/badge pickup line on site</li>
+    <li>Advance admission to the Dealers' Room each day</li>
+    <li>An invitation to the Artists & Dealers reception on Friday evening</li>
+    <li>Prime seating at selected Main Ballroom events</li>
+    <li>A luncheon with the guests of honor (for pre-registered Supersponsors only!)</li>
+    <li>A unique gift available only to Anthrocon Supersponsors</li>
+    <li>An advance opportunity to register for a hotel room before general availability!</li>
+</ul>
+
+</body>
+</html>


### PR DESCRIPTION
Kick-in levels are hidden, so this adds a new pop-up that explains all
the "badge types" offered to attendees.
