### PR TITLE
Replace dealer_confirmation page

### DIFF
--- a/anthrocon_plugin/templates/preregistration/dealer_confirmation.html
+++ b/anthrocon_plugin/templates/preregistration/dealer_confirmation.html
@@ -1,0 +1,38 @@
+{% extends "./preregistration/preregbase.html" %}
+{% block title %}Dealer Application Received{% endblock %}
+{% block backlink %}{% endblock %}
+{% block content %}
+<div class="masthead">
+</div>
+<div class="panel panel-default" style="padding:15px;">
+    <h2>{% if c.AFTER_DEALER_REG_DEADLINE %}You've been added to our waitlist!{% else %}Thanks for applying as a Dealer!{% endif %}</h2>
+
+    We've received your application for {{ group.name }} to purchase a Dealer registration for {{ c.EVENT_NAME }}.
+
+    <br/><br/>
+    {% if c.AFTER_DEALER_REG_DEADLINE %}
+        Since the Dealers Room is currently full, you've been added to our waitlist, and we'll let you know if a spot opens up for you.
+    {% else %}
+        We receive a flood of applications every year, which we respond to in the order in which we receive them.
+        Approvals will be done as promptly as possible; usually within <strong>two weeks</strong> from application.
+    {% endif %}
+
+    <h3>What Happens Next</h3>
+    After approval, you will be emailed a link to manage your dealer registration. From this link, you will be able to:
+    <ul>
+        <li>Pay for your dealer registration, which includes the cost of tables and Memberships.</li>
+        <li>Register your Dealer Assistants.</li>
+        <li>After your badge and table payment is received, you may add and pay for additional Dealer Assistants.</li>
+    </ul>
+
+    Your Dealership Payment includes your table cost and all Memberships in your group.  After payment, you'll be sent a link
+    by email to follow if you wish to later upgrade your badge. Your Dealer Assistants will be able to upgrade their own
+    Memberships and pay for those upgrades on their own.
+
+    <br/><br/>Later, you will receive an additional email about your placement within the Dealers Room.
+
+    <br/><br/>In the event we cannot accommodate your Dealership, you will receive an email.
+
+    {% include "preregistration/disclaimers.html" %}
+</div>
+{% endblock %}


### PR DESCRIPTION
Since this is just a text page, it's better to replace it so we can change the text at-will. Fixes https://github.com/Anthrocon-Reg/anthrocon_plugin/issues/46.