### PR TITLE
Various fixes for preregistration

### DIFF
--- a/anthrocon_plugin/templates/groupextra.html
+++ b/anthrocon_plugin/templates/groupextra.html
@@ -1,4 +1,4 @@
-{% if group.is_dealer %}
+{% if group.is_dealer or new_dealer %}
 <script type="text/javascript">
     $(function() {
         $("#table_prices").hide();

--- a/anthrocon_plugin/templates/preregistration/dealer_confirmation.html
+++ b/anthrocon_plugin/templates/preregistration/dealer_confirmation.html
@@ -23,6 +23,7 @@
         <li>Pay for your dealer registration, which includes the cost of tables and Memberships.</li>
         <li>Register your Dealer Assistants.</li>
         <li>After your badge and table payment is received, you may add and pay for additional Dealer Assistants.</li>
+        <li>If you have any questions, email us at dealers@anthrocon.org, or tweet us at @AC_Dealers_Room.</li>
     </ul>
 
     Your Dealership Payment includes your table cost and all Memberships in your group.  After payment, you'll be sent a link

--- a/anthrocon_plugin/templates/regextra.html
+++ b/anthrocon_plugin/templates/regextra.html
@@ -34,11 +34,11 @@
         $.field('found_how').parents('.form-group').hide();
         {% if c.PAGE_PATH != '/registration/form' %}
             $.field('staffing').parents('.form-group').hide();
+            $.field('amount_extra').parents('.form-group').hide();
         {% endif %}
         $.field('can_spam').prop('checked', false).parents('.form-group').hide();
         if ($.field('affiliate')) { $.field('affiliate').parents('.form-group').remove(); }
         $('label[for="ec_phone"]').addClass('optional-field');
-        $.field('amount_extra').parents('.form-group').hide();
 
         // Change existing fields
         $('label[for="cellphone"]').css('font-weight', 'bold').text('Your Phone Number');


### PR DESCRIPTION
Fixes creating new dealers, the text on the dealer confirmation page, and setting the payment info in the admin form for attendees.