### PR TITLE
Make dealer prices correct for AC

### DIFF
--- a/anthrocon_plugin/models.py
+++ b/anthrocon_plugin/models.py
@@ -73,5 +73,5 @@ class Group:
         total = 0
         for attendee in self.attendees:
             if attendee.paid == c.PAID_BY_GROUP:
-                total += c.BADGE_PRICE if attendee.is_dealer else c.get_group_price(attendee.registered)
+                total += c.get_attendee_price(attendee.registered) if attendee.is_dealer else c.get_group_price(attendee.registered)
         return total


### PR DESCRIPTION
Fixes https://github.com/Anthrocon-Reg/anthrocon_plugin/issues/57, which was caused by the badge price being calculated based on current time rather than registered date.